### PR TITLE
react-scrips is not used

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "react-dom": "16.7.0",
         "react-router-dom": "4.3.1",
         "react-testing-library": "5.4.4",
+        "react-scripts": "2.1.3",
         "react": "16.7.0",
         "rimraf": "2.6.3",
         "storybook-readme": "4.0.5",
@@ -51,7 +52,6 @@
         "react-datepicker": "^2.0.0",
         "react-formatted-number-input": "^1.2.2",
         "react-modal": "^3.8.1",
-        "react-scripts": "2.1.3",
         "uniqid": "^5.0.3"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "react-dom": "16.7.0",
         "react-router-dom": "4.3.1",
         "react-testing-library": "5.4.4",
-        "react-scripts": "2.1.3",
         "react": "16.7.0",
         "rimraf": "2.6.3",
         "storybook-readme": "4.0.5",


### PR DESCRIPTION
This is to not interfere with the apps react-script. (version conflict)

----

There might be a problem with the project dependency tree.
It is likely not a bug in Create React App, but something you need to fix locally.

The react-scripts package provided by Create React App requires a dependency:

  "babel-loader": "8.0.5"

Don't try to install it manually: your package manager does it automatically.
However, a different version of babel-loader was detected higher up in the tree: