### PR TITLE
Changes "type" to "kind" in <Button> API docs.

### DIFF
--- a/src/common/components/Button/README.md
+++ b/src/common/components/Button/README.md
@@ -6,7 +6,7 @@ Buttons are used to invoke an event.
 
 | Name            | Required | Type          | Possible values                                                                     | Notes                                                            |
 | --------------- | -------- | ------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `type`          |          | string        | `'primary'`, `'secondary'`, `'secondaryNegative'`, `'success'`, `'warn'`, `'text'`, | Use `secondaryNegative` only if you have an off white background |
+| `kind`          |          | string        | `'primary'`, `'secondary'`, `'secondaryNegative'`, `'success'`, `'warn'`, `'text'`, | Use `secondaryNegative` only if you have an off white background |
 | `size`          |          | string        | `'small'`, `'medium'`, `'large'`                                                    |                                                                  |
 | `icon`          |          | `JSX.Element` |                                                                                     | Icon _must_ contain a height in the SVG to show up.              |
 | `iconAlignment` |          | string        | `'start'`, `'end'`                                                                  | Defaults to `start`                                              |


### PR DESCRIPTION
Fixes a minor doc left-over in the <Button> API by changing `type` to `kind`.