### PR TITLE
fix(usePromise): Add AbortSignal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 
 src/.DS_Store
 .DS_Store
+collector-portal-framework-0.0.0-development.tgz

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
     "tabWidth": 4,
     "trailingComma": "es5",
     "printWidth": 140,
-    "semi": true
+    "semi": true,
+    "arrowParens": "avoid"
 }

--- a/src/components/FetchHandler.tsx
+++ b/src/components/FetchHandler.tsx
@@ -27,7 +27,7 @@ export const FetchHandler = <TResult extends {}>({
     notFoundIndicator,
     loadingIndicator,
 }: Props<TResult>) => {
-    const { loading, data, error, trigger, errorCode } = usePromise(apiMethod);
+    const { loading, data, error, trigger } = usePromise(apiMethod);
     const [dependencyList, setDependencyList] = useState(undefined);
 
     useEffect(() => {
@@ -35,13 +35,13 @@ export const FetchHandler = <TResult extends {}>({
     }, [dependencyList, trigger]);
 
     const renderError = () => {
-        if (errorIndicator && (errorCode !== 404 && notFoundIndicator)) {
+        if (errorIndicator && error?.code !== 404 && notFoundIndicator) {
             return errorIndicator;
-        } else if (errorCode === 404 && notFoundIndicator) {
+        } else if (error?.code === 404 && notFoundIndicator) {
             return notFoundIndicator;
         }
 
-        return errorCode !== 401 ? <Alert type="error" message={errorText} /> : <Spinner centered />;
+        return error?.code !== 401 ? <Alert type="error" message={errorText} /> : <Spinner centered />;
     };
 
     return (

--- a/src/components/FetchHandler.tsx
+++ b/src/components/FetchHandler.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { usePromise } from '../hooks';
 import { Spinner, Alert } from '.';
 
 /**
  * @param data This is a render-prop which you use to only render your content when data has come into effect
- * @param setDependencyList This is a callback which you use to set the list of dependencies for the useEffect hook.
- * Using this will allow you to re-fetch the data if you have a dependency on a submit for example.
  */
-type Child<TResult> = (data: TResult, setDependencyList: (dependencies: any) => void) => React.ReactNode;
+type Child<TResult> = (data: TResult) => React.ReactNode;
 
 interface Props<TResult> {
-    apiMethod: () => Promise<TResult>;
+    apiMethod: (abortSignal?: AbortSignal) => Promise<TResult>;
     children: Child<TResult>;
     errorText: string;
     errorIndicator?: React.ReactNode;
@@ -28,11 +26,10 @@ export const FetchHandler = <TResult extends {}>({
     loadingIndicator,
 }: Props<TResult>) => {
     const { loading, data, error, trigger } = usePromise(apiMethod);
-    const [dependencyList, setDependencyList] = useState(undefined);
 
     useEffect(() => {
         trigger();
-    }, [dependencyList, trigger]);
+    }, [trigger]);
 
     const renderError = () => {
         if (errorIndicator && error?.code !== 404 && notFoundIndicator) {
@@ -48,7 +45,7 @@ export const FetchHandler = <TResult extends {}>({
         <>
             {loading && (loadingIndicator ? loadingIndicator : <Spinner centered />)}
             {error && renderError()}
-            {data && children(data, (dependencies: any) => setDependencyList(dependencies))}
+            {data && children(data)}
         </>
     );
 };

--- a/src/hooks/use-promise.ts
+++ b/src/hooks/use-promise.ts
@@ -1,16 +1,20 @@
 import { useState, useCallback } from 'react';
 
-export function usePromise<TResult>(promise: () => Promise<TResult>) {
+export function usePromise<TResult, TErrorResult extends {}>(promise: () => Promise<TResult>) {
     const [data, setData] = useState<TResult | undefined>(undefined);
     const [loading, setLoading] = useState(false);
-    const [error, setError] = useState(false);
-    const [errorCode, setErrorCode] = useState<number | undefined>(undefined);
+    const [error, setError] = useState<{ code: number; data: TErrorResult } | undefined>(undefined);
+
+    const resetPromiseData = () => {
+        setData(undefined);
+        setError(undefined);
+    };
 
     const trigger = useCallback(async () => {
         const controller = new AbortController();
 
         setLoading(true);
-        setError(false);
+        setError(undefined);
         setData(undefined);
 
         try {
@@ -18,8 +22,7 @@ export function usePromise<TResult>(promise: () => Promise<TResult>) {
 
             setData(result);
         } catch (error) {
-            setErrorCode(error.status);
-            setError(true);
+            setError({ code: error.status, data: error.content });
         }
 
         setLoading(false);
@@ -27,5 +30,5 @@ export function usePromise<TResult>(promise: () => Promise<TResult>) {
         return () => controller.abort();
     }, [promise]);
 
-    return { data, loading, error, trigger, errorCode };
+    return { data, loading, error, trigger, resetPromiseData };
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -30,7 +30,7 @@ const request = (method: string) => async (
     }
 
     if (extraHeaders) {
-        Object.keys(extraHeaders).forEach((key) => headers.append(key, extraHeaders[key]));
+        Object.keys(extraHeaders).forEach(key => headers.append(key, extraHeaders[key]));
     }
 
     const options: RequestInit = {
@@ -45,7 +45,7 @@ const request = (method: string) => async (
     }
 
     const getPromiseForStatus = (response: Response, stream: Promise<any>) =>
-        stream.then((content) =>
+        stream.then(content =>
             response.status >= 200 && response.status < 300 ? content : Promise.reject({ status: response.status, content })
         );
 


### PR DESCRIPTION
This fix adds AbortSignal parameter to usePromise hook and uses the AbortController signal to actually abort from the frameworks http implementation. Fixes FetchHandler that uses usePromise internally.

Also add error data to usePromise.